### PR TITLE
Update STMMAC VLAN Filtering

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -6297,9 +6297,12 @@ static int stmmac_vlan_rx_add_vid(struct net_device *ndev, __be16 proto, u16 vid
 	}
 
 	if (priv->hw->num_vlan) {
-		ret = stmmac_add_hw_vlan_rx_fltr(priv, ndev, priv->hw, proto, vid);
-		if (ret)
+		if(priv->hw->vlan_filter[0] & GENMASK(15, 0)) {
+			netdev_warn(ndev, "Native VLAN Taken\n");
 			goto err_pm_put;
+		}
+		else
+			stmmac_add_hw_vlan_rx_fltr(priv, ndev, priv->hw, proto, vid);
 	}
 err_pm_put:
 	pm_runtime_put(priv->device);

--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -6302,7 +6302,7 @@ static int stmmac_vlan_rx_add_vid(struct net_device *ndev, __be16 proto, u16 vid
 		}
 		else {
 			stmmac_add_hw_vlan_rx_fltr(priv, ndev, priv->hw, proto, vid);
-			netdev_warn(ndev, "Native VLAN Set To %d\n", vid);
+			netdev_info(ndev, "HW VLAN Filter Set To %d\n", vid);
 		}
 	}
 err_pm_put:

--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -6298,11 +6298,12 @@ static int stmmac_vlan_rx_add_vid(struct net_device *ndev, __be16 proto, u16 vid
 
 	if (priv->hw->num_vlan) {
 		if(priv->hw->vlan_filter[0] & GENMASK(15, 0)) {
-			netdev_warn(ndev, "Native VLAN Taken\n");
 			goto err_pm_put;
 		}
-		else
+		else {
 			stmmac_add_hw_vlan_rx_fltr(priv, ndev, priv->hw, proto, vid);
+			netdev_warn(ndev, "Native VLAN Set To %d\n", vid);
+		}
 	}
 err_pm_put:
 	pm_runtime_put(priv->device);


### PR DESCRIPTION
Allow VL:AN perfect match register to never be overwritten and use the VLAN hash table for matching purposes.  The perfect match VLAN must be removed before replacing.   When multiple VLANs are assigned, the first one is the "native" VLAN, which is the tag that can be removed or added directly by the GMAC.  All VLANs after the first are then added to the VLAN hash table which is used for matching purposes only.  Note the VLAN hash table can have only 16 entries.