### PR TITLE
Port datum b53134 driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 VERSION = 6
 PATCHLEVEL = 6
 SUBLEVEL = 116
-EXTRAVERSION = -datum.2
+EXTRAVERSION = -datum.3-mc.2
 NAME = Pinguïn Aangedreven
 
 # *DOCUMENTATION*

--- a/drivers/hwmon/Kconfig
+++ b/drivers/hwmon/Kconfig
@@ -1238,7 +1238,7 @@ config SENSORS_MCP9902_DATUM
 	  with internal thermal diode.
 
 	  This driver can also be built as a module. If so, the module
-	  will be called mcp9902-datum.
+	  will be called mcp9902_datum.
 
 	  This driver is for use with the Datum Systems Inc. SPI/I2C shorted bus
 	  management system that fixes the I2C and SPI bus clocks shorted together.

--- a/drivers/hwmon/ina2xx_datum.c
+++ b/drivers/hwmon/ina2xx_datum.c
@@ -709,7 +709,10 @@ static int ina2xx_probe(struct i2c_client *client)
 	if (chip == ina226)
 		data->groups[group++] = &ina226_group;
 
-	hwmon_dev = devm_hwmon_device_register_with_groups(dev, client->name,
+	char *name = devm_kstrdup(dev, client->name, GFP_KERNEL);
+	strreplace(name, '-', '_');
+
+	hwmon_dev = devm_hwmon_device_register_with_groups(dev, name,
 							   data, data->groups);
 	if (IS_ERR(hwmon_dev))
 		return PTR_ERR(hwmon_dev);
@@ -721,11 +724,11 @@ static int ina2xx_probe(struct i2c_client *client)
 }
 
 static const struct i2c_device_id ina2xx_id[] = {
-	{ "ina219-datum", ina219 },
-	{ "ina220-datum", ina219 },
-	{ "ina226-datum", ina226 },
-	{ "ina230-datum", ina226 },
-	{ "ina231-datum", ina226 },
+	{ "ina219_datum", ina219 },
+	{ "ina220_datum", ina219 },
+	{ "ina226_datum", ina226 },
+	{ "ina230_datum", ina226 },
+	{ "ina231_datum", ina226 },
 	{ }
 };
 MODULE_DEVICE_TABLE(i2c, ina2xx_id);
@@ -757,7 +760,7 @@ MODULE_DEVICE_TABLE(of, ina2xx_of_match);
 
 static struct i2c_driver ina2xx_driver = {
 	.driver = {
-		.name	= "ina2xx-datum",
+		.name	= "ina2xx_datum",
 		.of_match_table = of_match_ptr(ina2xx_of_match),
 	},
 	.probe		= ina2xx_probe,

--- a/drivers/hwmon/mcp9902_datum.c
+++ b/drivers/hwmon/mcp9902_datum.c
@@ -332,14 +332,14 @@ static int mcp9902_probe(struct i2c_client *new_client)
 	mcp9902_init_client(new_client);
 
 	hwmon_dev = devm_hwmon_device_register_with_groups(&new_client->dev,
-							   new_client->name,
+							   "mcp9902_datum",
 							   data,
 							   mcp9902_groups);
 	return PTR_ERR_OR_ZERO(hwmon_dev);
 }
 
 static const struct i2c_device_id mcp9902_id[] = {
-	{ "mcp9902-datum", 0 },
+	{ "mcp9902_datum", 0 },
 	{ }
 };
 MODULE_DEVICE_TABLE(i2c, mcp9902_id);
@@ -356,7 +356,7 @@ MODULE_DEVICE_TABLE(of, mcp9902_of_match);
 static struct i2c_driver mcp9902_driver = {
 	.class		= I2C_CLASS_HWMON,
 	.driver = {
-		.name	= "mcp9902-datum",
+		.name	= "mcp9902_datum",
 		.of_match_table = of_match_ptr(mcp9902_of_match),
 	},
 	.probe		= mcp9902_probe,

--- a/drivers/net/dsa/b53/b53_common.c
+++ b/drivers/net/dsa/b53/b53_common.c
@@ -20,6 +20,7 @@
 #include <linux/delay.h>
 #include <linux/export.h>
 #include <linux/gpio.h>
+#include <linux/gpio/consumer.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/platform_data/b53.h>
@@ -828,6 +829,24 @@ static void b53_switch_reset_gpio(struct b53_device *dev)
 
 	gpio_set_value(gpio, 1);
 	mdelay(20);
+
+	dev->current_page = 0xff;
+}
+
+static void b53_switch_reset_gpiod(struct b53_device *dev)
+{
+	struct gpio_desc *gpiod = dev->reset_gpiod;
+
+	if (IS_ERR(gpiod))
+		return;
+
+	/* Reset sequence: RESET low(5ms)->high(10ms)
+	 */
+	gpiod_set_value(gpiod, 1);		// Reset Asserted (Voltage Low)
+	mdelay(5);
+
+	gpiod_set_value(gpiod, 0);		// Reset De-Asserted (Voltage High)
+	mdelay(10);
 
 	dev->current_page = 0xff;
 }
@@ -2872,7 +2891,16 @@ EXPORT_SYMBOL(b53_switch_detect);
 
 int b53_switch_register(struct b53_device *dev)
 {
+	int i;
 	int ret;
+	u16 phyreg;
+
+	dev->reset_gpiod = devm_gpiod_get(dev->dev, "reset", GPIOD_OUT_HIGH);		// Reset Asserted (Voltage Low)
+	if (IS_ERR(dev->reset_gpiod)) {
+		dev_err(dev->ds->dev, "Failed to get reset GPIO\n");
+		return PTR_ERR(dev->reset_gpiod);
+	}
+	b53_switch_reset_gpiod(dev);
 
 	if (dev->pdata) {
 		dev->chip_id = dev->pdata->chip_id;
@@ -2889,7 +2917,18 @@ int b53_switch_register(struct b53_device *dev)
 	dev_info(dev->dev, "found switch: %s, rev %i\n",
 		 dev->name, dev->core_rev);
 
-	return dsa_register_switch(dev->ds);
+	ret = dsa_register_switch(dev->ds);
+	/* Disable integrated PHY ports */
+	for(i = 0; i < dev->num_ports; i++)
+	{
+		if((dev->enabled_ports & BIT(i)) && (i != dev->cpu_port) && (i != dev->imp_port))
+		{
+			b53_read16(dev, B53_PORT_MII_PAGE(i), B53_GMII_CTL, &phyreg);
+			phyreg |= GMII_PWR_DOWN;
+			b53_write16(dev, B53_PORT_MII_PAGE(i), B53_GMII_CTL, phyreg);
+		}
+	}
+	return ret;
 }
 EXPORT_SYMBOL(b53_switch_register);
 

--- a/drivers/net/dsa/b53/b53_common.c
+++ b/drivers/net/dsa/b53/b53_common.c
@@ -224,11 +224,73 @@ static const struct b53_mib_desc b53_mibs_58xx[] = {
 	{ 4, 0xe4, "TxPkts1024toMaxPktOcets" },
 };
 
+/* BCM53134 MIB counters */
+static const struct b53_mib_desc b53_mibs_134[] = {
+	{ 8, 0x00, "TxOctets" },
+	{ 4, 0x08, "TxDropPkts" },
+	{ 4, 0x0c, "TxQPKTQ0" },
+	{ 4, 0x10, "TxBroadcastPkts" },
+	{ 4, 0x14, "TxMulticastPkts" },
+	{ 4, 0x18, "TxUnicastPKts" },
+	{ 4, 0x1c, "TxCollisions" },
+	{ 4, 0x20, "TxSingleCollision" },
+	{ 4, 0x24, "TxMultipleCollision" },
+	{ 4, 0x28, "TxDeferredCollision" },
+	{ 4, 0x2c, "TxLateCollision" },
+	{ 4, 0x30, "TxExcessiveCollision" },
+	{ 4, 0x34, "TxFrameInDisc" },
+	{ 4, 0x38, "TxPausePkts" },
+	{ 4, 0x3c, "TxQPKTQ1" },
+	{ 4, 0x40, "TxQPKTQ2" },
+	{ 4, 0x44, "TxQPKTQ3" },
+	{ 4, 0x48, "TxQPKTQ4" },
+	{ 4, 0x4c, "TxQPKTQ5" },
+	{ 8, 0x50, "RxOctets" },
+	{ 4, 0x58, "RxUndersizePkts" },
+	{ 4, 0x5c, "RxPausePkts" },
+	{ 4, 0x60, "RxPkts64Octets" },
+	{ 4, 0x64, "RxPkts65to127Octets" },
+	{ 4, 0x68, "RxPkts128to255Octets" },
+	{ 4, 0x6c, "RxPkts256to511Octets" },
+	{ 4, 0x70, "RxPkts512to1023Octets" },
+	{ 4, 0x74, "RxPkts1024toMaxPktsOctets" },
+	{ 4, 0x78, "RxOversizePkts" },
+	{ 4, 0x7c, "RxJabbers" },
+	{ 4, 0x80, "RxAlignmentErrors" },
+	{ 4, 0x84, "RxFCSErrors" },
+	{ 8, 0x88, "RxGoodOctets" },
+	{ 4, 0x90, "RxDropPkts" },
+	{ 4, 0x94, "RxUnicastPkts" },
+	{ 4, 0x98, "RxMulticastPkts" },
+	{ 4, 0x9c, "RxBroadcastPkts" },
+	{ 4, 0xa0, "RxSAChanges" },
+	{ 4, 0xa4, "RxFragments" },
+	{ 4, 0xa8, "RxJumboPkt" },
+	{ 4, 0xac, "RxSymblErr" },
+	{ 4, 0xb0, "InRangeErrCount" },
+	{ 4, 0xb4, "OutRangeErrCount" },
+	{ 4, 0xb8, "EEELpiEvent" },
+	{ 4, 0xbc, "EEELpiDuration" },
+	{ 4, 0xc0, "RxDiscard" },
+	{ 4, 0xc8, "TxQPKTQ6" },
+	{ 4, 0xcc, "TxQPKTQ7" },
+	{ 4, 0xd0, "TxPkts64Octets" },
+	{ 4, 0xd4, "TxPkts65to127Octets" },
+	{ 4, 0xd8, "TxPkts128to255Octets" },
+	{ 4, 0xdc, "TxPkts256to511Ocets" },
+	{ 4, 0xe0, "TxPkts512to1023Ocets" },
+	{ 4, 0xe4, "TxPkts1024toMaxPktOcets" },
+};
+
+#define B53_MIBS_134_SIZE	ARRAY_SIZE(b53_mibs_134)
+
 #define B53_MIBS_58XX_SIZE	ARRAY_SIZE(b53_mibs_58xx)
 
 #define B53_MAX_MTU_25		(1536 - ETH_HLEN - VLAN_HLEN - ETH_FCS_LEN)
 #define B53_MAX_MTU		(9720 - ETH_HLEN - VLAN_HLEN - ETH_FCS_LEN)
 
+/* Datum : Handle all VLAN operations via sysfs, not using Linux bridge controls */
+#if 0
 static int b53_do_vlan_op(struct b53_device *dev, u8 op)
 {
 	unsigned int i;
@@ -326,6 +388,7 @@ static void b53_get_vlan_entry(struct b53_device *dev, u16 vid,
 		vlan->valid = true;
 	}
 }
+#endif /* Datum : Handle all VLAN operations via sysfs, not using Linux bridge controls */
 
 static void b53_set_forwarding(struct b53_device *dev, int enable)
 {
@@ -359,6 +422,8 @@ static void b53_set_forwarding(struct b53_device *dev, int enable)
 	}
 }
 
+/* Datum : Handle all VLAN operations via sysfs, not using Linux bridge controls */
+#if 0
 static void b53_enable_vlan(struct b53_device *dev, int port, bool enable,
 			    bool enable_filtering)
 {
@@ -447,24 +512,20 @@ static void b53_enable_vlan(struct b53_device *dev, int port, bool enable,
 	dev_dbg(dev->dev, "Port %d VLAN enabled: %d, filtering: %d\n",
 		port, enable, enable_filtering);
 }
+#endif /* Datum : Handle all VLAN operations via sysfs, not using Linux bridge controls */
 
-static int b53_set_jumbo(struct b53_device *dev, bool enable, bool allow_10_100)
+static int b53_set_jumbo(struct b53_device *dev, int port, bool enable, bool allow_10_100)
 {
-	u32 port_mask = 0;
-	u16 max_size = JMS_MIN_SIZE;
-
-	if (is5325(dev) || is5365(dev))
-		return -EINVAL;
-
-	if (enable) {
-		port_mask = dev->enabled_ports;
-		max_size = JMS_MAX_SIZE;
-		if (allow_10_100)
-			port_mask |= JPM_10_100_JUMBO_EN;
-	}
-
-	b53_write32(dev, B53_JUMBO_PAGE, dev->jumbo_pm_reg, port_mask);
-	return b53_write16(dev, B53_JUMBO_PAGE, dev->jumbo_size_reg, max_size);
+	u32 port_mask;
+	b53_read32(dev, B53_JUMBO_PAGE, dev->jumbo_pm_reg, &port_mask);
+	port_mask &= ~JPM_RESERVED_BITS;
+	if (enable)
+		port_mask |= BIT(port);
+	else
+		port_mask &= ~BIT(port);
+	if (allow_10_100)
+		port_mask |= JPM_10_100_JUMBO_EN;
+	return b53_write32(dev, B53_JUMBO_PAGE, dev->jumbo_pm_reg, port_mask);
 }
 
 static int b53_flush_arl(struct b53_device *dev, u8 mask)
@@ -493,6 +554,8 @@ out:
 	return 0;
 }
 
+/* Datum:  VLANs are handled via sysfs, not using Linux bridge controls */
+#if 0
 static int b53_fast_age_port(struct b53_device *dev, int port)
 {
 	b53_write8(dev, B53_CTRL_PAGE, B53_FAST_AGE_PORT_CTRL, port);
@@ -528,6 +591,7 @@ void b53_imp_vlan_setup(struct dsa_switch *ds, int cpu_port)
 	}
 }
 EXPORT_SYMBOL(b53_imp_vlan_setup);
+#endif /* Datum:  VLANs are handled via sysfs, not using Linux bridge controls */
 
 static void b53_port_set_ucast_flood(struct b53_device *dev, int port,
 				     bool unicast)
@@ -612,7 +676,8 @@ int b53_enable_port(struct dsa_switch *ds, int port, struct phy_device *phy)
 	pvlan |= dev->ports[port].vlan_ctl_mask;
 	b53_write16(dev, B53_PVLAN_PAGE, B53_PVLAN_PORT_MASK(port), pvlan);
 
-	b53_imp_vlan_setup(ds, cpu_port);
+	/* Datum BCM53134 VLAN setup handles in net/dsa */
+	/* b53_imp_vlan_setup(ds, cpu_port); */
 
 	/* If EEE was enabled, restore it */
 	if (dev->ports[port].eee.eee_enabled)
@@ -640,73 +705,41 @@ EXPORT_SYMBOL(b53_disable_port);
 void b53_brcm_hdr_setup(struct dsa_switch *ds, int port)
 {
 	struct b53_device *dev = ds->priv;
-	bool tag_en = !(dev->tag_protocol == DSA_TAG_PROTO_NONE);
+	bool tag_en;
 	u8 hdr_ctl, val;
-	u16 reg;
 
 	/* Resolve which bit controls the Broadcom tag */
 	switch (port) {
 	case 8:
 		val = BRCM_HDR_P8_EN;
+		tag_en = !(dev->tag_protocol_imp == DSA_TAG_PROTO_NONE);
 		break;
 	case 7:
 		val = BRCM_HDR_P7_EN;
+		tag_en = false;
 		break;
 	case 5:
 		val = BRCM_HDR_P5_EN;
+		tag_en =  !(dev->tag_protocol_cpu == DSA_TAG_PROTO_NONE);
 		break;
 	default:
 		val = 0;
+		tag_en = false;
 		break;
 	}
 
-	/* Enable management mode if tagging is requested */
+	/* Always disable management mode */
 	b53_read8(dev, B53_CTRL_PAGE, B53_SWITCH_MODE, &hdr_ctl);
-	if (tag_en)
-		hdr_ctl |= SM_SW_FWD_MODE;
-	else
-		hdr_ctl &= ~SM_SW_FWD_MODE;
+	hdr_ctl &= ~SM_SW_FWD_MODE;
 	b53_write8(dev, B53_CTRL_PAGE, B53_SWITCH_MODE, hdr_ctl);
 
-	/* Configure the appropriate IMP port */
-	b53_read8(dev, B53_MGMT_PAGE, B53_GLOBAL_CONFIG, &hdr_ctl);
-	if (port == 8)
-		hdr_ctl |= GC_FRM_MGMT_PORT_MII;
-	else if (port == 5)
-		hdr_ctl |= GC_FRM_MGMT_PORT_M;
-	b53_write8(dev, B53_MGMT_PAGE, B53_GLOBAL_CONFIG, hdr_ctl);
-
-	/* Enable Broadcom tags for IMP port */
+	/* Configure Broadcom tags for IMP/CPU port */
 	b53_read8(dev, B53_MGMT_PAGE, B53_BRCM_HDR, &hdr_ctl);
 	if (tag_en)
 		hdr_ctl |= val;
 	else
 		hdr_ctl &= ~val;
 	b53_write8(dev, B53_MGMT_PAGE, B53_BRCM_HDR, hdr_ctl);
-
-	/* Registers below are only accessible on newer devices */
-	if (!is58xx(dev))
-		return;
-
-	/* Enable reception Broadcom tag for CPU TX (switch RX) to
-	 * allow us to tag outgoing frames
-	 */
-	b53_read16(dev, B53_MGMT_PAGE, B53_BRCM_HDR_RX_DIS, &reg);
-	if (tag_en)
-		reg &= ~BIT(port);
-	else
-		reg |= BIT(port);
-	b53_write16(dev, B53_MGMT_PAGE, B53_BRCM_HDR_RX_DIS, reg);
-
-	/* Enable transmission of Broadcom tags from the switch (CPU RX) to
-	 * allow delivering frames to the per-port net_devices
-	 */
-	b53_read16(dev, B53_MGMT_PAGE, B53_BRCM_HDR_TX_DIS, &reg);
-	if (tag_en)
-		reg &= ~BIT(port);
-	else
-		reg |= BIT(port);
-	b53_write16(dev, B53_MGMT_PAGE, B53_BRCM_HDR_TX_DIS, reg);
 }
 EXPORT_SYMBOL(b53_brcm_hdr_setup);
 
@@ -714,9 +747,21 @@ static void b53_enable_cpu_port(struct b53_device *dev, int port)
 {
 	u8 port_ctrl;
 
-	/* BCM5325 CPU port is at 8 */
-	if ((is5325(dev) || is5365(dev)) && port == B53_CPU_PORT_25)
-		port = B53_CPU_PORT;
+	port_ctrl = PORT_CTRL_RX_BCST_EN |
+		    PORT_CTRL_RX_MCST_EN |
+		    PORT_CTRL_RX_UCST_EN;
+	b53_write8(dev, B53_CTRL_PAGE, B53_PORT_CTRL(port), port_ctrl);
+
+	b53_brcm_hdr_setup(dev->ds, port);
+
+	b53_port_set_ucast_flood(dev, port, true);
+	b53_port_set_mcast_flood(dev, port, true);
+	b53_port_set_learning(dev, port, false);
+}
+
+static void b53_enable_imp_port(struct b53_device *dev, int port)
+{
+	u8 port_ctrl;
 
 	port_ctrl = PORT_CTRL_RX_BCST_EN |
 		    PORT_CTRL_RX_MCST_EN |
@@ -739,6 +784,8 @@ static void b53_enable_mib(struct b53_device *dev)
 	b53_write8(dev, B53_MGMT_PAGE, B53_GLOBAL_CONFIG, gc);
 }
 
+/* Datum:  No STP and VLANs handles in sysfs */
+#if 0
 static void b53_enable_stp(struct b53_device *dev)
 {
 	u8 gc;
@@ -762,54 +809,14 @@ static bool b53_vlan_port_needs_forced_tagged(struct dsa_switch *ds, int port)
 
 	return dev->tag_protocol == DSA_TAG_PROTO_NONE && dsa_is_cpu_port(ds, port);
 }
+#endif /* Datum:  No STP and VLANs handles in sysfs */
 
 int b53_configure_vlan(struct dsa_switch *ds)
 {
 	struct b53_device *dev = ds->priv;
-	struct b53_vlan vl = { 0 };
-	struct b53_vlan *v;
-	int i, def_vid;
-	u16 vid;
 
-	def_vid = b53_default_pvid(dev);
-
-	/* clear all vlan entries */
-	if (is5325(dev) || is5365(dev)) {
-		for (i = def_vid; i < dev->num_vlans; i++)
-			b53_set_vlan_entry(dev, i, &vl);
-	} else {
-		b53_do_vlan_op(dev, VTA_CMD_CLEAR);
-	}
-
-	b53_enable_vlan(dev, -1, dev->vlan_enabled, ds->vlan_filtering);
-
-	/* Create an untagged VLAN entry for the default PVID in case
-	 * CONFIG_VLAN_8021Q is disabled and there are no calls to
-	 * dsa_slave_vlan_rx_add_vid() to create the default VLAN
-	 * entry. Do this only when the tagging protocol is not
-	 * DSA_TAG_PROTO_NONE
-	 */
-	b53_for_each_port(dev, i) {
-		v = &dev->vlans[def_vid];
-		v->members |= BIT(i);
-		if (!b53_vlan_port_needs_forced_tagged(ds, i))
-			v->untag = v->members;
-		b53_write16(dev, B53_VLAN_PAGE,
-			    B53_VLAN_PORT_DEF_TAG(i), def_vid);
-	}
-
-	/* Upon initial call we have not set-up any VLANs, but upon
-	 * system resume, we need to restore all VLAN entries.
-	 */
-	for (vid = def_vid; vid < dev->num_vlans; vid++) {
-		v = &dev->vlans[vid];
-
-		if (!v->members)
-			continue;
-
-		b53_set_vlan_entry(dev, vid, v);
-		b53_fast_age_vlan(dev, vid);
-	}
+	/* Join all VLANs for all ports (promiscuous mode) */
+	b53_write16(dev, B53_VLAN_PAGE, B53_JOIN_ALL_VLAN_EN, VJA_ALL_PORTS_MASK);
 
 	return 0;
 }
@@ -905,7 +912,8 @@ static int b53_switch_reset(struct b53_device *dev)
 	}
 
 	b53_enable_mib(dev);
-	b53_enable_stp(dev);
+	/* Datum :  No STP */
+	//b53_enable_stp(dev);
 
 	return b53_flush_arl(dev, FAST_AGE_STATIC);
 }
@@ -973,26 +981,12 @@ static void b53_reset_mib(struct b53_device *priv)
 
 static const struct b53_mib_desc *b53_get_mib(struct b53_device *dev)
 {
-	if (is5365(dev))
-		return b53_mibs_65;
-	else if (is63xx(dev))
-		return b53_mibs_63xx;
-	else if (is58xx(dev))
-		return b53_mibs_58xx;
-	else
-		return b53_mibs;
+	return b53_mibs_134;
 }
 
 static unsigned int b53_get_mib_size(struct b53_device *dev)
 {
-	if (is5365(dev))
-		return B53_MIBS_65_SIZE;
-	else if (is63xx(dev))
-		return B53_MIBS_63XX_SIZE;
-	else if (is58xx(dev))
-		return B53_MIBS_58XX_SIZE;
-	else
-		return B53_MIBS_SIZE;
+	return B53_MIBS_134_SIZE;
 }
 
 static struct phy_device *b53_get_phy_device(struct dsa_switch *ds, int port)
@@ -1040,8 +1034,10 @@ void b53_get_ethtool_stats(struct dsa_switch *ds, int port, uint64_t *data)
 	unsigned int i;
 	u64 val = 0;
 
-	if (is5365(dev) && port == 5)
-		port = 8;
+	/* Datum:  Remove following to prevent false part match
+	*	if (is5365(dev) && port == 5)
+	*		port = 8;
+	*/
 
 	mutex_lock(&dev->stats_mutex);
 
@@ -1143,6 +1139,11 @@ out:
 }
 EXPORT_SYMBOL(b53_setup_devlink_resources);
 
+static inline bool dsa_is_imp_port(struct dsa_switch *ds, int p)
+{
+	return p == B53_CPU_PORT;
+}
+
 static int b53_setup(struct dsa_switch *ds)
 {
 	struct b53_device *dev = ds->priv;
@@ -1152,7 +1153,7 @@ static int b53_setup(struct dsa_switch *ds)
 	/* Request bridge PVID untagged when DSA_TAG_PROTO_NONE is set
 	 * which forces the CPU port to be tagged in all VLANs.
 	 */
-	ds->untag_bridge_pvid = dev->tag_protocol == DSA_TAG_PROTO_NONE;
+	ds->untag_bridge_pvid = dev->tag_protocol_cpu == DSA_TAG_PROTO_NONE;
 
 	ret = b53_reset_switch(dev);
 	if (ret) {
@@ -1174,9 +1175,17 @@ static int b53_setup(struct dsa_switch *ds)
 	for (port = 0; port < dev->num_ports; port++) {
 		if (dsa_is_cpu_port(ds, port))
 			b53_enable_cpu_port(dev, port);
+		else if(dsa_is_imp_port(ds, port))
+			b53_enable_imp_port(dev, port);
 		else
 			b53_disable_port(ds, port);
 	}
+	/* Disable all port based VLANs on powerup.  Userspace configuration
+	 * will enable them as needed.  Note, PVLAN bit mask for each port
+	 * must be set to include itself per data sheet.
+	 */
+	for (port = 0; port < dev->num_ports; port++)
+		b53_write16(dev, B53_PVLAN_PAGE, B53_PVLAN_PORT_MASK(port), BIT(port));
 
 	return b53_setup_devlink_resources(ds);
 }
@@ -1301,16 +1310,12 @@ static void b53_adjust_link(struct dsa_switch *ds, int port,
 {
 	struct b53_device *dev = ds->priv;
 	struct ethtool_eee *p = &dev->ports[port].eee;
-	u8 rgmii_ctrl = 0, reg = 0, off;
+	u8 rgmii_ctrl = 0, off;
 	bool tx_pause = false;
 	bool rx_pause = false;
 
 	if (!phy_is_pseudo_fixed_link(phydev))
 		return;
-
-	/* Enable flow control on BCM5301x's CPU port */
-	if (is5301x(dev) && dsa_is_cpu_port(ds, port))
-		tx_pause = rx_pause = true;
 
 	if (phydev->pause) {
 		if (phydev->asym_pause)
@@ -1325,7 +1330,7 @@ static void b53_adjust_link(struct dsa_switch *ds, int port,
 	if (is63xx(dev) && port >= B53_63XX_RGMII0)
 		b53_adjust_63xx_rgmii(ds, port, phydev->interface);
 
-	if (is531x5(dev) && phy_interface_is_rgmii(phydev)) {
+	if (phy_interface_is_rgmii(phydev)) {
 		if (port == dev->imp_port)
 			off = B53_RGMII_CTRL_IMP;
 		else
@@ -1334,9 +1339,7 @@ static void b53_adjust_link(struct dsa_switch *ds, int port,
 		/* Configure the port RGMII clock delay by DLL disabled and
 		 * tx_clk aligned timing (restoring to reset defaults)
 		 */
-		b53_read8(dev, B53_CTRL_PAGE, off, &rgmii_ctrl);
-		rgmii_ctrl &= ~(RGMII_CTRL_DLL_RXC | RGMII_CTRL_DLL_TXC |
-				RGMII_CTRL_TIMING_SEL);
+		rgmii_ctrl = 0x00;
 
 		/* PHY_INTERFACE_MODE_RGMII_TXID means TX internal delay, make
 		 * sure that we enable the port TX clock internal delay to
@@ -1354,33 +1357,15 @@ static void b53_adjust_link(struct dsa_switch *ds, int port,
 		 */
 		if (phydev->interface == PHY_INTERFACE_MODE_RGMII_TXID)
 			rgmii_ctrl |= RGMII_CTRL_DLL_TXC;
-		if (phydev->interface == PHY_INTERFACE_MODE_RGMII)
-			rgmii_ctrl |= RGMII_CTRL_DLL_TXC | RGMII_CTRL_DLL_RXC;
-		rgmii_ctrl |= RGMII_CTRL_TIMING_SEL;
+		if (phydev->interface == PHY_INTERFACE_MODE_RGMII_RXID)
+			rgmii_ctrl |= RGMII_CTRL_DLL_RXC;
+		if (phydev->interface == PHY_INTERFACE_MODE_RGMII_ID)
+			rgmii_ctrl |= (RGMII_CTRL_DLL_TXC | RGMII_CTRL_DLL_RXC);
+
 		b53_write8(dev, B53_CTRL_PAGE, off, rgmii_ctrl);
 
-		dev_info(ds->dev, "Configured port %d for %s\n", port,
-			 phy_modes(phydev->interface));
-	}
-
-	/* configure MII port if necessary */
-	if (is5325(dev)) {
-		b53_read8(dev, B53_CTRL_PAGE, B53_PORT_OVERRIDE_CTRL,
-			  &reg);
-
-		/* reverse mii needs to be enabled */
-		if (!(reg & PORT_OVERRIDE_RV_MII_25)) {
-			b53_write8(dev, B53_CTRL_PAGE, B53_PORT_OVERRIDE_CTRL,
-				   reg | PORT_OVERRIDE_RV_MII_25);
-			b53_read8(dev, B53_CTRL_PAGE, B53_PORT_OVERRIDE_CTRL,
-				  &reg);
-
-			if (!(reg & PORT_OVERRIDE_RV_MII_25)) {
-				dev_err(ds->dev,
-					"Failed to enable reverse MII mode\n");
-				return;
-			}
-		}
+		dev_info(ds->dev, "Configured port %d for %s (reg=0x%02x)\n", port,
+			 phy_modes(phydev->interface), rgmii_ctrl);
 	}
 
 	/* Re-negotiate EEE if it was enabled already */
@@ -1509,6 +1494,8 @@ void b53_phylink_mac_link_up(struct dsa_switch *ds, int port,
 }
 EXPORT_SYMBOL(b53_phylink_mac_link_up);
 
+/* Datum : Handle all VLAN operations via sysfs, not using Linux bridge controls */
+#if 0
 int b53_vlan_filtering(struct dsa_switch *ds, int port, bool vlan_filtering,
 		       struct netlink_ext_ack *extack)
 {
@@ -1624,6 +1611,7 @@ int b53_vlan_del(struct dsa_switch *ds, int port,
 	return 0;
 }
 EXPORT_SYMBOL(b53_vlan_del);
+#endif /* Datum : Handle all VLAN operations via sysfs, not using Linux bridge controls */
 
 /* Address Resolution Logic routines. Caller must hold &dev->arl_mutex. */
 static int b53_arl_op_wait(struct b53_device *dev)
@@ -1789,12 +1777,6 @@ int b53_fdb_add(struct dsa_switch *ds, int port,
 	struct b53_device *priv = ds->priv;
 	int ret;
 
-	/* 5325 and 5365 require some more massaging, but could
-	 * be supported eventually
-	 */
-	if (is5325(priv) || is5365(priv))
-		return -EOPNOTSUPP;
-
 	mutex_lock(&priv->arl_mutex);
 	ret = b53_arl_op(priv, 0, port, addr, vid, true);
 	mutex_unlock(&priv->arl_mutex);
@@ -1912,12 +1894,6 @@ int b53_mdb_add(struct dsa_switch *ds, int port,
 	struct b53_device *priv = ds->priv;
 	int ret;
 
-	/* 5325 and 5365 require some more massaging, but could
-	 * be supported eventually
-	 */
-	if (is5325(priv) || is5365(priv))
-		return -EOPNOTSUPP;
-
 	mutex_lock(&priv->arl_mutex);
 	ret = b53_arl_op(priv, 0, port, mdb->addr, mdb->vid, true);
 	mutex_unlock(&priv->arl_mutex);
@@ -1943,6 +1919,8 @@ int b53_mdb_del(struct dsa_switch *ds, int port,
 }
 EXPORT_SYMBOL(b53_mdb_del);
 
+/* Datum: linux bridge functions not used within L2 switch */
+#if 0
 int b53_br_join(struct dsa_switch *ds, int port, struct dsa_bridge bridge,
 		bool *tx_fwd_offload, struct netlink_ext_ack *extack)
 {
@@ -2119,6 +2097,7 @@ int b53_br_flags(struct dsa_switch *ds, int port,
 	return 0;
 }
 EXPORT_SYMBOL(b53_br_flags);
+#endif /* Datum: linux bridge functions not used within L2 switch */
 
 static bool b53_possible_cpu_port(struct dsa_switch *ds, int port)
 {
@@ -2151,7 +2130,7 @@ static bool b53_can_enable_brcm_tags(struct dsa_switch *ds, int port,
 	case DSA_TAG_PROTO_BRCM_PREPEND:
 		dev_warn(ds->dev,
 			 "Port %d is stacked to Broadcom tag switch\n", port);
-		ret = false;
+		ret = true;
 		break;
 	default:
 		ret = true;
@@ -2166,30 +2145,34 @@ enum dsa_tag_protocol b53_get_tag_protocol(struct dsa_switch *ds, int port,
 {
 	struct b53_device *dev = ds->priv;
 
-	if (!b53_can_enable_brcm_tags(ds, port, mprot)) {
-		dev->tag_protocol = DSA_TAG_PROTO_NONE;
-		goto out;
-	}
-
-	/* Older models require a different 6 byte tag */
-	if (is5325(dev) || is5365(dev) || is63xx(dev)) {
-		dev->tag_protocol = DSA_TAG_PROTO_BRCM_LEGACY;
-		goto out;
-	}
-
-	/* Broadcom BCM58xx chips have a flow accelerator on Port 8
-	 * which requires us to use the prepended Broadcom tag type
-	 */
-	if (dev->chip_id == BCM58XX_DEVICE_ID && port == B53_CPU_PORT) {
-		dev->tag_protocol = DSA_TAG_PROTO_BRCM_PREPEND;
-		goto out;
-	}
-
-	dev->tag_protocol = DSA_TAG_PROTO_BRCM;
-out:
-	return dev->tag_protocol;
+	if(port == dev->cpu_port)
+		return dev->tag_protocol_cpu;
+	if(port == dev->imp_port)
+		return dev->tag_protocol_imp;
+	
+	return DSA_TAG_PROTO_NONE;
 }
 EXPORT_SYMBOL(b53_get_tag_protocol);
+
+/* Datum:  This is used only for changing the cpu port tag protocol.
+ *         The imp port is handled outside of the DSA framework
+ */
+
+int b53_change_tag_protocol(struct dsa_switch *ds,
+				enum dsa_tag_protocol mprot)
+{
+	struct b53_device *dev = ds->priv;
+	int port = dev->cpu_port;
+	if (!b53_can_enable_brcm_tags(ds, port, mprot))
+		return -EOPNOTSUPP;
+	if(dev->tag_protocol_cpu == mprot)
+		return 0;
+	dev->tag_protocol_cpu = mprot;
+	b53_brcm_hdr_setup(ds, port);
+
+	return 0;
+}
+EXPORT_SYMBOL(b53_change_tag_protocol);
 
 int b53_mirror_add(struct dsa_switch *ds, int port,
 		   struct dsa_mall_mirror_tc_entry *mirror, bool ingress,
@@ -2293,9 +2276,6 @@ int b53_get_mac_eee(struct dsa_switch *ds, int port, struct ethtool_eee *e)
 	struct ethtool_eee *p = &dev->ports[port].eee;
 	u16 reg;
 
-	if (is5325(dev) || is5365(dev))
-		return -EOPNOTSUPP;
-
 	b53_read16(dev, B53_EEE_PAGE, B53_EEE_LPI_INDICATE, &reg);
 	e->eee_enabled = p->eee_enabled;
 	e->eee_active = !!(reg & BIT(port));
@@ -2308,9 +2288,6 @@ int b53_set_mac_eee(struct dsa_switch *ds, int port, struct ethtool_eee *e)
 {
 	struct b53_device *dev = ds->priv;
 	struct ethtool_eee *p = &dev->ports[port].eee;
-
-	if (is5325(dev) || is5365(dev))
-		return -EOPNOTSUPP;
 
 	p->eee_enabled = e->eee_enabled;
 	b53_eee_enable_set(ds, port, e->eee_enabled);
@@ -2325,30 +2302,96 @@ static int b53_change_mtu(struct dsa_switch *ds, int port, int mtu)
 	bool enable_jumbo;
 	bool allow_10_100;
 
-	if (is5325(dev) || is5365(dev))
-		return 0;
-
-	if (!dsa_is_cpu_port(ds, port))
-		return 0;
-
 	enable_jumbo = (mtu > ETH_DATA_LEN);
-	allow_10_100 = !is63xx(dev);
+	allow_10_100 = true;
 
-	return b53_set_jumbo(dev, enable_jumbo, allow_10_100);
+	return b53_set_jumbo(dev, port, enable_jumbo, allow_10_100);
 }
 
 static int b53_get_max_mtu(struct dsa_switch *ds, int port)
 {
-	struct b53_device *dev = ds->priv;
-
-	if (is5325(dev) || is5365(dev))
-		return B53_MAX_MTU_25;
-
-	return B53_MAX_MTU;
+	return JMS_MAX_SIZE;
 }
 
+static int b53_port_change_pvlan(struct dsa_switch *ds, int port, u16 mask)
+{
+	struct b53_device *dev = ds->priv;
+
+	b53_write16(dev, B53_PVLAN_PAGE, B53_PVLAN_PORT_MASK(port), mask);
+	dev->ports[port].vlan_ctl_mask = mask;
+	return 0;
+}
+
+static int b53_port_get_pvlan(struct dsa_switch *ds, int port, u16 *mask)
+{
+	struct b53_device *dev = ds->priv;
+	u16 reg;
+	b53_read16(dev, B53_PVLAN_PAGE, B53_PVLAN_PORT_MASK(port), &reg);
+	*mask = reg & 0x1ff;
+
+	return 0;
+}
+
+static int b53_switch_setup_get_reg(struct dsa_switch *ds, u8 page, u8 reg, u8 size)
+{
+	struct b53_device *dev = ds->priv;
+
+	dev->page = page;
+	dev->reg = reg;
+	dev->size = size;
+
+	return 0;
+}
+
+static int b53_switch_get_reg(struct dsa_switch *ds, u8 *size, u64 *value)
+{
+	struct b53_device *dev = ds->priv;
+	
+	*size = dev->size;
+	switch(dev->size) {
+		case 1: 
+			return b53_read8(dev, dev->page, dev->reg, (u8 *)value);
+		case 2:
+			return b53_read16(dev, dev->page, dev->reg, (u16 *)value);
+		case 4:
+			return b53_read32(dev, dev->page, dev->reg, (u32 *)value);
+		case 6:
+			return b53_read48(dev, dev->page, dev->reg, value);
+		case 8:	
+			return b53_read64(dev, dev->page, dev->reg, value);
+		default:
+			return -EINVAL;	
+	}
+
+	return 0;
+}
+
+static int b53_switch_set_reg(struct dsa_switch *ds, u8 page, u8 reg, u8 size, u64 value)
+{
+	struct b53_device *dev = ds->priv;
+	
+	switch(size) {
+		case 1: 
+			return b53_write8(dev, page, reg, (u8)value);
+		case 2:
+			return b53_write16(dev, page, reg, (u16)value);
+		case 4:
+			return b53_write32(dev, page, reg, (u32)value);
+		case 6:
+			return b53_write48(dev, page, reg, (u64)value);
+		case 8:	
+			return b53_write64(dev, page, reg, (u64)value);
+		default:
+			return -EINVAL;	
+	}
+
+	return 0;
+}
+
+/* Datum: Removed unused functions */
 static const struct dsa_switch_ops b53_switch_ops = {
 	.get_tag_protocol	= b53_get_tag_protocol,
+	.change_tag_protocol	= b53_change_tag_protocol,
 	.setup			= b53_setup,
 	.teardown		= b53_teardown,
 	.get_strings		= b53_get_strings,
@@ -2367,15 +2410,9 @@ static const struct dsa_switch_ops b53_switch_ops = {
 	.port_disable		= b53_disable_port,
 	.get_mac_eee		= b53_get_mac_eee,
 	.set_mac_eee		= b53_set_mac_eee,
-	.port_bridge_join	= b53_br_join,
-	.port_bridge_leave	= b53_br_leave,
-	.port_pre_bridge_flags	= b53_br_flags_pre,
-	.port_bridge_flags	= b53_br_flags,
-	.port_stp_state_set	= b53_br_set_stp_state,
-	.port_fast_age		= b53_br_fast_age,
-	.port_vlan_filtering	= b53_vlan_filtering,
-	.port_vlan_add		= b53_vlan_add,
-	.port_vlan_del		= b53_vlan_del,
+	//.port_pre_bridge_flags	= b53_br_flags_pre,
+	//.port_bridge_flags	= b53_br_flags,
+	//.port_fast_age		= b53_br_fast_age,
 	.port_fdb_dump		= b53_fdb_dump,
 	.port_fdb_add		= b53_fdb_add,
 	.port_fdb_del		= b53_fdb_del,
@@ -2385,6 +2422,11 @@ static const struct dsa_switch_ops b53_switch_ops = {
 	.port_mdb_del		= b53_mdb_del,
 	.port_max_mtu		= b53_get_max_mtu,
 	.port_change_mtu	= b53_change_mtu,
+	.port_change_pvlan	= b53_port_change_pvlan,
+	.port_get_pvlan		= b53_port_get_pvlan,
+	.switch_setup_get_reg	= b53_switch_setup_get_reg,
+	.switch_get_reg 	= b53_switch_get_reg,
+	.switch_set_reg		= b53_switch_set_reg
 };
 
 struct b53_chip_data {
@@ -2684,7 +2726,7 @@ static const struct b53_chip_data b53_switch_chips[] = {
 		.vlans = 4096,
 		.enabled_ports = 0x12f,
 		.imp_port = 8,
-		.cpu_port = B53_CPU_PORT,
+		.cpu_port = B53_CPU_PORT_25,
 		.vta_regs = B53_VTA_REGS,
 		.arl_bins = 4,
 		.arl_buckets = 1024,
@@ -2698,6 +2740,7 @@ static int b53_switch_init(struct b53_device *dev)
 {
 	unsigned int i;
 	int ret;
+	u16 phyreg;
 
 	for (i = 0; i < ARRAY_SIZE(b53_switch_chips); i++) {
 		const struct b53_chip_data *chip = &b53_switch_chips[i];
@@ -2719,50 +2762,42 @@ static int b53_switch_init(struct b53_device *dev)
 		}
 	}
 
-	/* check which BCM5325x version we have */
-	if (is5325(dev)) {
-		u8 vc4;
-
-		b53_read8(dev, B53_VLAN_PAGE, B53_VLAN_CTRL4_25, &vc4);
-
-		/* check reserved bits */
-		switch (vc4 & 3) {
-		case 1:
-			/* BCM5325E */
-			break;
-		case 3:
-			/* BCM5325F - do not use port 4 */
-			dev->enabled_ports &= ~BIT(4);
-			break;
-		default:
-/* On the BCM47XX SoCs this is the supported internal switch.*/
-#ifndef CONFIG_BCM47XX
-			/* BCM5325M */
-			return -EINVAL;
-#else
-			break;
-#endif
-		}
-	}
-
+	dev->enabled_ports |= BIT(dev->cpu_port);
 	dev->num_ports = fls(dev->enabled_ports);
 
 	dev->ds->num_ports = min_t(unsigned int, dev->num_ports, DSA_MAX_PORTS);
 
 	/* Include non standard CPU port built-in PHYs to be probed */
-	if (is539x(dev) || is531x5(dev)) {
-		for (i = 0; i < dev->num_ports; i++) {
-			if (!(dev->ds->phys_mii_mask & BIT(i)) &&
-			    !b53_possible_cpu_port(dev->ds, i))
-				dev->ds->phys_mii_mask |= BIT(i);
-		}
+	for (i = 0; i < dev->num_ports; i++) {
+		if (!(dev->ds->phys_mii_mask & BIT(i)) &&
+			!b53_possible_cpu_port(dev->ds, i))
+			dev->ds->phys_mii_mask |= BIT(i);
 	}
+
+	/* Default cpu to no tagging, imp Port to brcm tagging */
+	dev->tag_protocol_cpu = DSA_TAG_PROTO_NONE;
+	dev->tag_protocol_imp = DSA_TAG_PROTO_BRCM;
 
 	dev->ports = devm_kcalloc(dev->dev,
 				  dev->num_ports, sizeof(struct b53_port),
 				  GFP_KERNEL);
 	if (!dev->ports)
 		return -ENOMEM;
+
+	/* Disable integrated PHY ports */
+	for(i = 0; i < dev->num_ports; i++)
+	{
+		if((dev->enabled_ports & BIT(i)) && (i != dev->cpu_port) && (i != dev->imp_port))
+		{
+			ret = b53_read16(dev, B53_PORT_MII_PAGE(i), B53_GMII_CTL, &phyreg);
+			if(ret)
+				return ret;
+			phyreg |= GMII_PWR_DOWN;
+			ret = b53_write16(dev, B53_PORT_MII_PAGE(i), B53_GMII_CTL, phyreg);
+			if(ret)
+				return ret;
+		}
+	}
 
 	dev->vlans = devm_kcalloc(dev->dev,
 				  dev->num_vlans, sizeof(struct b53_vlan),
@@ -2918,7 +2953,7 @@ int b53_switch_register(struct b53_device *dev)
 		 dev->name, dev->core_rev);
 
 	ret = dsa_register_switch(dev->ds);
-	/* Disable integrated PHY ports */
+
 	for(i = 0; i < dev->num_ports; i++)
 	{
 		if((dev->enabled_ports & BIT(i)) && (i != dev->cpu_port) && (i != dev->imp_port))

--- a/drivers/net/dsa/b53/b53_priv.h
+++ b/drivers/net/dsa/b53/b53_priv.h
@@ -125,7 +125,7 @@ struct b53_device {
 	int reset_gpio;
 	u8 num_arl_bins;
 	u16 num_arl_buckets;
-	enum dsa_tag_protocol tag_protocol;
+	enum dsa_tag_protocol tag_protocol_cpu;
 	enum dsa_tag_protocol tag_protocol_imp;
 
 	/* raw register read data*/
@@ -398,6 +398,8 @@ int b53_mirror_add(struct dsa_switch *ds, int port,
 		   struct netlink_ext_ack *extack);
 enum dsa_tag_protocol b53_get_tag_protocol(struct dsa_switch *ds, int port,
 					   enum dsa_tag_protocol mprot);
+int b53_change_tag_protocol(struct dsa_switch *ds,
+				enum dsa_tag_protocol mprot);					   
 void b53_mirror_del(struct dsa_switch *ds, int port,
 		    struct dsa_mall_mirror_tc_entry *mirror);
 int b53_enable_port(struct dsa_switch *ds, int port, struct phy_device *phy);

--- a/drivers/net/dsa/b53/b53_priv.h
+++ b/drivers/net/dsa/b53/b53_priv.h
@@ -113,6 +113,7 @@ struct b53_device {
 	struct mutex stats_mutex;
 	struct mutex arl_mutex;
 	const struct b53_io_ops *ops;
+	struct gpio_desc *reset_gpiod;
 
 	/* chip specific data */
 	u32 chip_id;
@@ -125,10 +126,17 @@ struct b53_device {
 	u8 num_arl_bins;
 	u16 num_arl_buckets;
 	enum dsa_tag_protocol tag_protocol;
+	enum dsa_tag_protocol tag_protocol_imp;
+
+	/* raw register read data*/
+	u8 page;
+	u8 reg;
+	u8 size;
 
 	/* used ports mask */
 	u16 enabled_ports;
 	unsigned int imp_port;
+	unsigned int cpu_port;
 
 	/* connect specific data */
 	u8 current_page;

--- a/drivers/net/dsa/b53/b53_regs.h
+++ b/drivers/net/dsa/b53/b53_regs.h
@@ -405,7 +405,7 @@
 
 /* Join all VLANs register (16 bit) */
 #define B53_JOIN_ALL_VLAN_EN		0x50
-#define VJA_ALL_PORTS_MASK		    0x12f
+#define VJA_ALL_PORTS_MASK			0x12f
 
 /*************************************************************************
  * 802.1Q Page Registers
@@ -515,6 +515,7 @@
 #define B53_JUMBO_PORT_MASK		0x01
 #define B53_JUMBO_PORT_MASK_63XX	0x04
 #define   JPM_10_100_JUMBO_EN		BIT(24) /* GigE always enabled */
+#define   JPM_RESERVED_BITS			0xfefffe00
 
 /* Good Frame Max Size without 802.1Q TAG (16 bit) */
 #define B53_JUMBO_MAX_SIZE		0x05

--- a/drivers/net/dsa/b53/b53_regs.h
+++ b/drivers/net/dsa/b53/b53_regs.h
@@ -358,6 +358,45 @@
 #define B53_ARL_SRCH_RSTL(x)		(B53_ARL_SRCH_RSTL_0 + ((x) * 0x10))
 
 /*************************************************************************
+ * Port MII Registers
+ *************************************************************************/
+ #define B53_GMII_CTL			0x00
+ #define  GMII_CTL_RESET		BIT(15)
+ #define  GMII_CTL_LOOPBACK		BIT(14)
+ #define  GMII_CTL_SPD_SEL_LSB		BIT(13)
+ #define  GMII_AN_EN			BIT(12)
+ #define  GMII_PWR_DOWN			BIT(11)
+ #define  GMII_ISOLATE			BIT(10)
+ #define  GMII_RESTART_AN		BIT(9)
+ #define  GMII_DUPLEX			BIT(8)
+ #define  GMII_COLL_TEST		BIT(7)
+ #define  GMII_SPD_SEL_MSB		BIT(6)
+ #define B53_GMII_STS			0x02
+ #define B53_PHY_IDH			0x04
+ #define B53_PHY_IDL			0x06
+ #define B53_AN_ADV			0x08
+ #define B53_AN_LPA			0x0a
+ #define B53_AN_EXP			0x0c
+ #define B53_AN_NXP			0x0e
+ #define B53_LP_NXP			0x10
+ #define B53_B1000T_CTL			0x12
+ #define B53_B1000T_STS			0x14
+ #define B53_EXT_STS			0x1e
+ #define B53_PHY_EXT_CTL		0x20
+ #define B53_PHY_EXT_STS		0x22
+ #define B53_REC_ERR_CNT		0x24
+ #define B53_FALSE_CARR_CNT		0x26
+ #define B53_REC_NOTOK_CNT		0x28
+ #define B53_DSP_COEFFICIENT		0x2a
+ #define B53_DSP_COEFFICIENT_ADDR	0x2e
+ #define B53_AUX_CTL			0x30
+ #define B53_AUX_STS			0x32
+ #define B53_INTERRUPT_STS		0x34
+ #define B53_INTERRUPT_MSK		0x36
+ #define B53_MISC_SHADOW		0x38
+ #define B53_LED_CTRL			0x3a
+
+/*************************************************************************
  * Port VLAN Registers
  *************************************************************************/
 
@@ -366,6 +405,7 @@
 
 /* Join all VLANs register (16 bit) */
 #define B53_JOIN_ALL_VLAN_EN		0x50
+#define VJA_ALL_PORTS_MASK		    0x12f
 
 /*************************************************************************
  * 802.1Q Page Registers

--- a/drivers/net/dsa/b53/b53_spi_datum.c
+++ b/drivers/net/dsa/b53/b53_spi_datum.c
@@ -47,15 +47,15 @@ EXPORT_SYMBOL(datum_spi2_i2c3_clock_short);
 
 inline void datum_b53_spi_mutex_lock(void)
 { 
-	if(datum_spi2_i2c3_clock_short)
-		mutex_lock(&datum_b53_spi_mutex);
+	// TODO: remove when working if(datum_spi2_i2c3_clock_short)
+	// TODO: remove when working 	mutex_lock(&datum_b53_spi_mutex);
 }
 EXPORT_SYMBOL(datum_b53_spi_mutex_lock);
 
 inline void datum_b53_spi_mutex_unlock(struct device *dev)
 {
-	if(datum_spi2_i2c3_clock_short)
-		mutex_unlock(&datum_b53_spi_mutex);
+	// TODO: remove when working if(datum_spi2_i2c3_clock_short)
+	// TODO: remove when working 	mutex_unlock(&datum_b53_spi_mutex);
 }
 EXPORT_SYMBOL(datum_b53_spi_mutex_unlock);
 
@@ -428,7 +428,7 @@ MODULE_DEVICE_TABLE(spi, b53_spi_ids);
 
 static struct spi_driver b53_spi_driver = {
 	.driver = {
-		.name	= "b53-switch-datum",
+		.name	= "bcm53134_datum",
 		.of_match_table = b53_spi_of_match,
 	},
 	.probe	= b53_spi_probe,

--- a/drivers/net/dsa/b53/b53_spi_datum.c
+++ b/drivers/net/dsa/b53/b53_spi_datum.c
@@ -47,15 +47,15 @@ EXPORT_SYMBOL(datum_spi2_i2c3_clock_short);
 
 inline void datum_b53_spi_mutex_lock(void)
 { 
-	// TODO: remove when working if(datum_spi2_i2c3_clock_short)
-	// TODO: remove when working 	mutex_lock(&datum_b53_spi_mutex);
+	if(datum_spi2_i2c3_clock_short)
+		mutex_lock(&datum_b53_spi_mutex);
 }
 EXPORT_SYMBOL(datum_b53_spi_mutex_lock);
 
 inline void datum_b53_spi_mutex_unlock(struct device *dev)
 {
-	// TODO: remove when working if(datum_spi2_i2c3_clock_short)
-	// TODO: remove when working 	mutex_unlock(&datum_b53_spi_mutex);
+	if(datum_spi2_i2c3_clock_short)
+		mutex_unlock(&datum_b53_spi_mutex);
 }
 EXPORT_SYMBOL(datum_b53_spi_mutex_unlock);
 

--- a/include/net/dsa.h
+++ b/include/net/dsa.h
@@ -262,6 +262,7 @@ struct dsa_port {
 		DSA_PORT_TYPE_CPU,
 		DSA_PORT_TYPE_DSA,
 		DSA_PORT_TYPE_USER,
+		DSA_PORT_TYPE_IMP
 	} type;
 
 	const char		*name;
@@ -512,7 +513,7 @@ static inline bool dsa_port_is_cpu(struct dsa_port *port)
 
 static inline bool dsa_port_is_user(struct dsa_port *dp)
 {
-	return dp->type == DSA_PORT_TYPE_USER;
+	return (dp->type == DSA_PORT_TYPE_USER) || (dp->type == DSA_PORT_TYPE_IMP);
 }
 
 static inline bool dsa_port_is_unused(struct dsa_port *dp)
@@ -543,7 +544,7 @@ static inline bool dsa_is_dsa_port(struct dsa_switch *ds, int p)
 
 static inline bool dsa_is_user_port(struct dsa_switch *ds, int p)
 {
-	return dsa_to_port(ds, p)->type == DSA_PORT_TYPE_USER;
+	return dsa_to_port(ds, p)->type == DSA_PORT_TYPE_USER || dsa_to_port(ds, p)->type == DSA_PORT_TYPE_IMP;
 }
 
 #define dsa_tree_for_each_user_port(_dp, _dst) \
@@ -1220,6 +1221,19 @@ struct dsa_switch_ops {
 	int	(*tag_8021q_vlan_add)(struct dsa_switch *ds, int port, u16 vid,
 				      u16 flags);
 	int	(*tag_8021q_vlan_del)(struct dsa_switch *ds, int port, u16 vid);
+
+	/*
+	 * Port-based VLAN operations
+	 */
+	 int	(*port_change_pvlan)(struct dsa_switch *ds, int port, u16 mask);
+	 int	(*port_get_pvlan)(struct dsa_switch *ds, int port, u16 *mask);
+
+	/*
+	 * Switch low level register read/write
+	 */
+	 int 	(*switch_setup_get_reg)(struct dsa_switch *ds, u8 page, u8 reg, u8 size);
+	 int	(*switch_get_reg)(struct dsa_switch *ds, u8 *size, u64 *value);
+	 int	(*switch_set_reg)(struct dsa_switch *ds, u8 page, u8 reg, u8 size, u64 value);
 
 	/*
 	 * DSA master tracking operations

--- a/linux-linux.code-workspace
+++ b/linux-linux.code-workspace
@@ -6,13 +6,28 @@
 	],
 	"settings": {
 		"clangd.checkUpdates": true,
-
 		"editor.stickyTabStops": true,
 		"clangd.enableCodeCompletion": true,
 		"clangd.enableHover": true,
 		"editor.inlayHints.enabled": "off",
 		"clangd.arguments": [
 			"--enable-config"
-		]
+		],
+		"editor.defaultFormatter": null,
+
+		"editor.detectIndentation": false,
+
+		"[c]": {
+			"editor.insertSpaces": false,
+			"editor.tabSize": 4
+		},
+		"[cpp]": {
+			"editor.insertSpaces": false,
+			"editor.tabSize": 4
+		},
+		"[h]": {
+			"editor.insertSpaces": false,
+			"editor.tabSize": 4
+		}
 	}
 }

--- a/linux.code-workspace
+++ b/linux.code-workspace
@@ -7,13 +7,28 @@
 	"remoteAuthority": "wsl+Ubuntu-22.04",
 	"settings": {
 		"clangd.checkUpdates": true,
-
 		"editor.stickyTabStops": true,
 		"clangd.enableCodeCompletion": true,
 		"clangd.enableHover": true,
 		"editor.inlayHints.enabled": "off",
 		"clangd.arguments": [
 			"--enable-config"
-		]
+		],
+		"editor.defaultFormatter": null,
+
+		"editor.detectIndentation": false,
+
+		"[c]": {
+			"editor.insertSpaces": false,
+			"editor.tabSize": 4
+		},
+		"[cpp]": {
+			"editor.insertSpaces": false,
+			"editor.tabSize": 4
+		},
+		"[h]": {
+			"editor.insertSpaces": false,
+			"editor.tabSize": 4
+		}
 	}
 }

--- a/net/dsa/devlink.c
+++ b/net/dsa/devlink.c
@@ -325,6 +325,9 @@ int dsa_port_devlink_setup(struct dsa_port *dp)
 	case DSA_PORT_TYPE_DSA:
 		attrs.flavour = DEVLINK_PORT_FLAVOUR_DSA;
 		break;
+	case DSA_PORT_TYPE_IMP:
+		attrs.flavour = DEVLINK_PORT_FLAVOUR_PHYSICAL;
+		break;
 	case DSA_PORT_TYPE_USER:
 		attrs.flavour = DEVLINK_PORT_FLAVOUR_PHYSICAL;
 		break;

--- a/net/dsa/dsa.c
+++ b/net/dsa/dsa.c
@@ -463,6 +463,7 @@ static void dsa_tree_teardown_cpu_ports(struct dsa_switch_tree *dst)
 
 static int dsa_port_setup(struct dsa_port *dp)
 {
+	struct devlink_port *dlp = &dp->devlink_port;
 	bool dsa_port_link_registered = false;
 	struct dsa_switch *ds = dp->ds;
 	bool dsa_port_enabled = false;
@@ -496,6 +497,23 @@ static int dsa_port_setup(struct dsa_port *dp)
 			break;
 		dsa_port_enabled = true;
 
+		break;
+	case DSA_PORT_TYPE_IMP:
+		err = dsa_shared_port_link_register_of(dp);
+		if (err)
+			break;
+		dsa_port_link_registered = true;
+
+		err = dsa_port_enable(dp, NULL);
+		if (err)
+			break;
+		dsa_port_enabled = true;
+
+		of_get_mac_address(dp->dn, dp->mac);
+		err = dsa_slave_create(dp);
+		if (err)
+			break;
+		devlink_port_type_eth_set(dlp);
 		break;
 	case DSA_PORT_TYPE_DSA:
 		if (dp->dn) {
@@ -547,6 +565,12 @@ static void dsa_port_teardown(struct dsa_port *dp)
 		dsa_port_disable(dp);
 		if (dp->dn)
 			dsa_shared_port_link_unregister_of(dp);
+		break;
+	case DSA_PORT_TYPE_IMP:
+		if (dp->slave) {
+			dsa_slave_destroy(dp->slave);
+			dp->slave = NULL;
+		}
 		break;
 	case DSA_PORT_TYPE_DSA:
 		dsa_port_disable(dp);
@@ -1135,6 +1159,17 @@ static int dsa_port_parse_dsa(struct dsa_port *dp)
 	return 0;
 }
 
+static int dsa_port_parse_imp(struct dsa_port *dp, const char *name)
+{
+	if (!name)
+		name = "imp%d";
+
+	dp->type = DSA_PORT_TYPE_IMP;
+	dp->name = name;
+
+	return 0;
+}
+
 static enum dsa_tag_protocol dsa_get_tag_protocol(struct dsa_port *dp,
 						  struct net_device *master)
 {
@@ -1158,6 +1193,7 @@ static enum dsa_tag_protocol dsa_get_tag_protocol(struct dsa_port *dp,
 	/* If the master device is not itself a DSA slave in a disjoint DSA
 	 * tree, then return immediately.
 	 */
+	tag_protocol =  ds->ops->get_tag_protocol(ds, dp->index, tag_protocol);
 	return ds->ops->get_tag_protocol(ds, dp->index, tag_protocol);
 }
 
@@ -1265,6 +1301,10 @@ static int dsa_port_parse_of(struct dsa_port *dp, struct device_node *dn)
 
 		user_protocol = of_get_property(dn, "dsa-tag-protocol", NULL);
 		return dsa_port_parse_cpu(dp, master, user_protocol);
+	}
+
+	if(of_property_read_bool(dn, "port-imp")) {
+		return dsa_port_parse_imp(dp, name);
 	}
 
 	if (link)

--- a/net/dsa/master.c
+++ b/net/dsa/master.c
@@ -15,6 +15,12 @@
 #include "master.h"
 #include "port.h"
 #include "tag.h"
+/*
+ * SPI2-I2C3 Clocks Shorted Mutex Control
+ */
+
+void datum_b53_spi_mutex_lock(void);
+void datum_b53_spi_mutex_force_unlock(void);
 
 static int dsa_master_get_regs_len(struct net_device *dev)
 {
@@ -277,7 +283,7 @@ static void dsa_master_set_promiscuity(struct net_device *dev, int inc)
 	dev_set_promiscuity(dev, inc);
 }
 
-static ssize_t tagging_show(struct device *d, struct device_attribute *attr,
+static ssize_t tagging_cpu_show(struct device *d, struct device_attribute *attr,
 			    char *buf)
 {
 	struct net_device *dev = to_net_dev(d);
@@ -287,7 +293,7 @@ static ssize_t tagging_show(struct device *d, struct device_attribute *attr,
 		       dsa_tag_protocol_to_str(cpu_dp->tag_ops));
 }
 
-static ssize_t tagging_store(struct device *d, struct device_attribute *attr,
+static ssize_t tagging_cpu_store(struct device *d, struct device_attribute *attr,
 			     const char *buf, size_t count)
 {
 	const struct dsa_device_ops *new_tag_ops, *old_tag_ops;
@@ -334,10 +340,242 @@ out:
 	dsa_tag_driver_put(old_tag_ops);
 	return count;
 }
-static DEVICE_ATTR_RW(tagging);
+static DEVICE_ATTR_RW(tagging_cpu);
+
+static ssize_t tagging_imp_show(struct device *d, struct device_attribute *attr,
+			    char *buf)
+{
+	struct net_device *dev = to_net_dev(d);
+	struct dsa_port *cpu_dp = dev->dsa_ptr;
+	struct dsa_switch *ds = cpu_dp->ds;
+	const struct dsa_device_ops *tag_ops;
+	enum dsa_tag_protocol proto;
+
+	proto = ds->ops->get_tag_protocol(ds, 8, DSA_TAG_PROTO_NONE);
+	tag_ops = dsa_tag_driver_get(proto);
+	return sprintf(buf, "%s\n", dsa_tag_protocol_to_str(tag_ops));
+}
+
+static ssize_t tagging_imp_store(struct device *d, struct device_attribute *attr,
+			     const char *buf, size_t count)
+{
+	const struct dsa_device_ops *new_tag_ops;
+	struct net_device *dev = to_net_dev(d);
+	struct dsa_port *cpu_dp = dev->dsa_ptr;
+	struct dsa_switch *ds = cpu_dp->ds;
+
+	new_tag_ops = dsa_tag_driver_get_by_name(buf);
+	/* Bad tagger name, or module is not loaded? */
+	if (IS_ERR(new_tag_ops))
+		return PTR_ERR(new_tag_ops);
+
+	if(!ds->ops->change_tag_protocol)
+		return -EOPNOTSUPP;
+
+	ds->ops->change_tag_protocol(ds, new_tag_ops->proto);
+	return count;
+}
+static DEVICE_ATTR_RW(tagging_imp);
+
+static ssize_t pvlan_show(struct device *d, struct device_attribute *attr,
+			  char *buf)
+{
+	struct net_device *dev = to_net_dev(d);
+	struct dsa_port *cpu_dp = dev->dsa_ptr;
+	struct dsa_switch_tree *dst = cpu_dp->ds->dst;
+	struct dsa_port *dp;
+	int len = 0;
+	u16 value;
+
+	list_for_each_entry(dp, &dst->ports, list) {
+		if (dp->type != DSA_PORT_TYPE_UNUSED) {
+			if(!dp->ds->ops->port_change_pvlan)
+				return -EOPNOTSUPP;
+			dp->ds->ops->port_get_pvlan(dp->ds, dp->index, &value);
+			len += sprintf(buf + len, "%d:%03hx ", dp->index,  value);
+		}
+	}
+
+	len += sprintf(buf + len, "\n");
+
+	return len;
+}
+
+static ssize_t pvlan_store(struct device *d, struct device_attribute *attr,
+			   const char *buf, size_t count)
+{
+	struct net_device *dev = to_net_dev(d);
+	struct dsa_port *cpu_dp = dev->dsa_ptr;
+	struct dsa_switch_tree *dst = cpu_dp->ds->dst;
+	struct dsa_switch *ds = cpu_dp->ds;
+	struct dsa_port *dp;
+	int index;
+	u16 value;
+	int err;
+
+	// Parse the input
+	err = sscanf(buf, "%d:%hx", &index, &value);
+	if (err != 2)
+		return -EINVAL;  // Invalid format
+
+	// Find the port with the given index
+	list_for_each_entry(dp, &dst->ports, list) {
+		if (dp->index == index && dp->type != DSA_PORT_TYPE_UNUSED) {
+			if(!dp->ds->ops->port_get_pvlan)
+				return -EOPNOTSUPP;
+			// Apply the new value
+			dp->ds->ops->port_change_pvlan(ds, index, value);
+			return count;
+		}
+	}
+
+	// No port with the given index was found
+	return -EINVAL;
+}
+static DEVICE_ATTR_RW(pvlan);
+
+static ssize_t rdreg_show(struct device *d, struct device_attribute *attr,
+			char *buf)
+{
+	struct net_device *dev = to_net_dev(d);
+	struct dsa_port *cpu_dp = dev->dsa_ptr;
+	struct dsa_switch *ds = cpu_dp->ds;
+	u8 size;
+	u64 value;
+	int len = 0;
+
+	if(ds->ops->switch_get_reg(ds, &size, &value))
+		return -EIO;
+	switch(size) {
+		case 1:
+			len += sprintf(buf + len, "%hhx\n", (u8)value);
+			break;
+		case 2:
+			len += sprintf(buf + len, "%hx\n", (u16)value);
+			break;
+		case 4:
+			len += sprintf(buf + len, "%x\n", (u32)value);	
+			break;
+		case 6:
+			len += sprintf(buf + len, "%llx\n", value);
+			break;
+		case 8:
+			len += sprintf(buf + len, "%llx\n", value);
+			break;
+		default:
+			return -EIO;
+	}
+	return len;
+}
+
+static ssize_t rdreg_store(struct device *d, struct device_attribute *attr,
+			 const char *buf, size_t count)
+{
+	struct net_device *dev = to_net_dev(d);
+	struct dsa_port *cpu_dp = dev->dsa_ptr;
+	struct dsa_switch *ds = cpu_dp->ds;
+	u8 page;
+	u8 reg;
+	u8 size;
+	int err;
+
+	// Parse the input
+	err = sscanf(buf, "%hhx:%hhx:%hhx" , &page, &reg, &size);
+	if (err != 3)
+		return -EINVAL;  // Invalid format
+
+	// Write the value to the private data
+	if(ds->ops->switch_setup_get_reg(ds, page, reg, size))
+		return -EIO;
+
+	return count;
+}
+static DEVICE_ATTR_RW(rdreg);
+
+static ssize_t wrreg_show(struct device *d, struct device_attribute *attr,
+			char *buf)
+{
+	return -EPERM;
+}
+
+static ssize_t wrreg_store(struct device *d, struct device_attribute *attr,
+			const char *buf, size_t count)
+{
+	struct net_device *dev = to_net_dev(d);
+	struct dsa_port *cpu_dp = dev->dsa_ptr;
+	struct dsa_switch *ds = cpu_dp->ds;
+	u8 page;
+	u8 reg;
+	u8 size;
+	u64 value;
+	int err;
+
+	// Parse the input
+	err = sscanf(buf, "%hhx:%hhx:%hhx:%llx" , &page, &reg, &size, &value);
+	if (err != 4)
+		return -EINVAL;  // Invalid format
+
+	// Write the value to the switch
+	if(ds->ops->switch_set_reg(ds, page, reg, size, value))
+		return -EIO;
+
+	return count;
+}
+static DEVICE_ATTR_RW(wrreg);
+
+static ssize_t spi_mutex_show(struct device *d, struct device_attribute *attr,
+			char *buf)
+{
+	int len = 0;
+	extern bool datum_spi2_i2c3_clock_short;
+
+	if(datum_spi2_i2c3_clock_short)
+		len = sprintf(buf, "1\n");
+	else
+		len = sprintf(buf, "0\n");
+	return len;
+}
+
+static ssize_t spi_mutex_store(struct device *d, struct device_attribute *attr,
+			 const char *buf, size_t count)
+{
+	// struct net_device *dev = to_net_dev(d);
+	// struct dsa_port *cpu_dp = dev->dsa_ptr;
+	// struct dsa_switch *ds = cpu_dp->ds;
+	// u8 page;
+	// u8 reg;
+	// u8 size;
+	int err;
+	int mutex_enable;
+	extern bool datum_spi2_i2c3_clock_short;
+
+	// Parse the input
+	if(count != 2)
+		return -EINVAL;  // Invalid format - one character expected plus null termination
+	err = sscanf(buf, "%d" , &mutex_enable);
+	if (err != 1)
+		return -EINVAL;  // Invalid format - one string parsed
+	if(mutex_enable != 0 && mutex_enable != 1)
+		return -EINVAL;  // Invalid format - not "0" or "1"
+	// Write the value to the private data
+	datum_b53_spi_mutex_lock();
+	if(mutex_enable)
+		datum_spi2_i2c3_clock_short = true;
+	else
+		datum_spi2_i2c3_clock_short = false;
+
+	datum_b53_spi_mutex_force_unlock();
+	return count;
+}
+static DEVICE_ATTR_RW(spi_mutex);
 
 static struct attribute *dsa_slave_attrs[] = {
-	&dev_attr_tagging.attr,
+	&dev_attr_tagging_cpu.attr,
+	&dev_attr_tagging_imp.attr,
+	&dev_attr_pvlan.attr,
+	&dev_attr_rdreg.attr,
+	&dev_attr_wrreg.attr,
+	&dev_attr_spi_mutex.attr,
 	NULL
 };
 

--- a/net/dsa/slave.c
+++ b/net/dsa/slave.c
@@ -2023,7 +2023,7 @@ static void dsa_bridge_mtu_normalization(struct dsa_port *dp)
 			struct dsa_hw_port *hw_port;
 			struct net_device *slave;
 
-			if (other_dp->type != DSA_PORT_TYPE_USER)
+			if ((other_dp->type != DSA_PORT_TYPE_USER) && (other_dp->type != DSA_PORT_TYPE_IMP))
 				continue;
 
 			if (!dsa_port_bridge_same(dp, other_dp))
@@ -2066,90 +2066,30 @@ out:
 	dsa_hw_port_list_free(&hw_port_list);
 }
 
+/* Datum - rewrite to unlink slave (switch ports) from master (eth0) */
 int dsa_slave_change_mtu(struct net_device *dev, int new_mtu)
 {
-	struct net_device *master = dsa_slave_to_master(dev);
 	struct dsa_port *dp = dsa_slave_to_port(dev);
-	struct dsa_port *cpu_dp = dp->cpu_dp;
-	struct dsa_switch *ds = dp->ds;
-	struct dsa_port *other_dp;
-	int largest_mtu = 0;
-	int new_master_mtu;
-	int old_master_mtu;
+	struct dsa_slave_priv *p = netdev_priv(dev);
+	struct dsa_switch *ds = p->dp->ds;
 	int mtu_limit;
-	int overhead;
-	int cpu_mtu;
 	int err;
 
 	if (!ds->ops->port_change_mtu)
 		return -EOPNOTSUPP;
 
-	dsa_tree_for_each_user_port(other_dp, ds->dst) {
-		int slave_mtu;
+	mtu_limit = dev->max_mtu;
 
-		/* During probe, this function will be called for each slave
-		 * device, while not all of them have been allocated. That's
-		 * ok, it doesn't change what the maximum is, so ignore it.
-		 */
-		if (!other_dp->slave)
-			continue;
-
-		/* Pretend that we already applied the setting, which we
-		 * actually haven't (still haven't done all integrity checks)
-		 */
-		if (dp == other_dp)
-			slave_mtu = new_mtu;
-		else
-			slave_mtu = other_dp->slave->mtu;
-
-		if (largest_mtu < slave_mtu)
-			largest_mtu = slave_mtu;
-	}
-
-	overhead = dsa_tag_protocol_overhead(cpu_dp->tag_ops);
-	mtu_limit = min_t(int, master->max_mtu, dev->max_mtu + overhead);
-	old_master_mtu = master->mtu;
-	new_master_mtu = largest_mtu + overhead;
-	if (new_master_mtu > mtu_limit)
+	if(new_mtu > mtu_limit)
 		return -ERANGE;
 
-	/* If the master MTU isn't over limit, there's no need to check the CPU
-	 * MTU, since that surely isn't either.
-	 */
-	cpu_mtu = largest_mtu;
-
-	/* Start applying stuff */
-	if (new_master_mtu != old_master_mtu) {
-		err = dev_set_mtu(master, new_master_mtu);
-		if (err < 0)
-			goto out_master_failed;
-
-		/* We only need to propagate the MTU of the CPU port to
-		 * upstream switches, so emit a notifier which updates them.
-		 */
-		err = dsa_port_mtu_change(cpu_dp, cpu_mtu);
-		if (err)
-			goto out_cpu_failed;
-	}
-
-	err = ds->ops->port_change_mtu(ds, dp->index, new_mtu);
+	err = dsa_port_mtu_change(dp, new_mtu);
 	if (err)
-		goto out_port_failed;
+		return err;
 
 	dev->mtu = new_mtu;
 
-	dsa_bridge_mtu_normalization(dp);
-
 	return 0;
-
-out_port_failed:
-	if (new_master_mtu != old_master_mtu)
-		dsa_port_mtu_change(cpu_dp, old_master_mtu - overhead);
-out_cpu_failed:
-	if (new_master_mtu != old_master_mtu)
-		dev_set_mtu(master, old_master_mtu);
-out_master_failed:
-	return err;
 }
 
 static int __maybe_unused
@@ -3182,11 +3122,14 @@ dsa_bridge_prechangelower_sanity_check(struct net_device *new_lower,
 		if (!netdev_uses_dsa(new_lower) && !netdev_uses_dsa(lower))
 			continue;
 
+		/* Datum:  allow bridging DSA master with non-DSA internal port (eth0 <--> tap0) */
+#if 0		
 		if (!netdev_port_same_parent_id(lower, new_lower)) {
 			NL_SET_ERR_MSG(extack,
 				       "Cannot do software bridging with a DSA master");
 			return notifier_from_errno(-EINVAL);
 		}
+#endif
 	}
 
 	return NOTIFY_DONE;

--- a/net/dsa/tag.c
+++ b/net/dsa/tag.c
@@ -241,3 +241,32 @@ void dsa_tag_driver_put(const struct dsa_device_ops *ops)
 	}
 	mutex_unlock(&dsa_tag_drivers_lock);
 }
+
+const struct dsa_device_ops *dsa_tag_driver_get(int tag_protocol)
+{
+	struct dsa_tag_driver *dsa_tag_driver;
+	const struct dsa_device_ops *ops;
+	bool found = false;
+
+	request_module("%s%d", DSA_TAG_DRIVER_ALIAS, tag_protocol);
+
+	mutex_lock(&dsa_tag_drivers_lock);
+	list_for_each_entry(dsa_tag_driver, &dsa_tag_drivers_list, list) {
+		ops = dsa_tag_driver->ops;
+		if (ops->proto == tag_protocol) {
+			found = true;
+			break;
+		}
+	}
+
+	if (found) {
+		if (!try_module_get(dsa_tag_driver->owner))
+			ops = ERR_PTR(-ENOPROTOOPT);
+	} else {
+		ops = ERR_PTR(-ENOPROTOOPT);
+	}
+
+	mutex_unlock(&dsa_tag_drivers_lock);
+
+	return ops;
+}

--- a/net/dsa/tag.h
+++ b/net/dsa/tag.h
@@ -22,6 +22,7 @@ extern struct packet_type dsa_pack_type;
 const struct dsa_device_ops *dsa_tag_driver_get_by_id(int tag_protocol);
 const struct dsa_device_ops *dsa_tag_driver_get_by_name(const char *name);
 void dsa_tag_driver_put(const struct dsa_device_ops *ops);
+const struct dsa_device_ops *dsa_tag_driver_get(int tag_protocol);
 const char *dsa_tag_protocol_to_str(const struct dsa_device_ops *ops);
 
 static inline int dsa_tag_protocol_overhead(const struct dsa_device_ops *ops)
@@ -38,7 +39,7 @@ static inline struct net_device *dsa_master_find_slave(struct net_device *dev,
 
 	list_for_each_entry(dp, &dst->ports, list)
 		if (dp->ds->index == device && dp->index == port &&
-		    dp->type == DSA_PORT_TYPE_USER)
+		    (dp->type == DSA_PORT_TYPE_USER || dp->type == DSA_PORT_TYPE_IMP))
 			return dp->slave;
 
 	return NULL;


### PR DESCRIPTION
This PR adds the Datum version of DSA b53 driver for Broadcom L2 switch support.   The Datum version is heavily modified to support the BCM53134 chip and allow VLAN changes outside of the normal Linux brctl framework.  This was done to properly implement the private (port-based) VLAN requirement.   Mostly tested bit the VLANs need some more testing.